### PR TITLE
Update nodejs demos

### DIFF
--- a/nodejs/demos/todos/todo.js
+++ b/nodejs/demos/todos/todo.js
@@ -16,11 +16,12 @@
 //
 var googleapis = require('googleapis');
 var authclient = new googleapis.auth.OAuth2();
-var datasetId = 'gcd-codelab';
 var compute = new googleapis.auth.Compute();
+var datastore = googleapis.datastore({ version: 'v1beta2', auth: compute });
+
 var todoListName = process.argv[2];
-var datastore = googleapis.datastore({ version: 'v1', auth: compute });
 var cmd = process.argv[3];
+var datasetId = 'gcd-codelab';
 
 var usage = 'usage todo.js <todolist> <add|get|del|edit|ls|archive> [todo-title|todo-id]';
 

--- a/nodejs/demos/trivial/adams.js
+++ b/nodejs/demos/trivial/adams.js
@@ -19,7 +19,7 @@ var util = require('util');
 var events = require('events');
 var readline = require('readline');
 var googleapis = require('googleapis');
-var datastore = googleapis.datastore('v1');
+var datastore = googleapis.datastore('v1beta2');
 
 var SCOPES = ['https://www.googleapis.com/auth/userinfo.email',
               'https://www.googleapis.com/auth/datastore'];


### PR DESCRIPTION
I've taken the liberty of trying to update the nodejs demos in this repo to work with the new google-api-nodejs-client. I haven't actually tested the changes so if someone could give this a second look & perhaps test it, that'd be awesome.

Plus general feedback is always welcome. Maybe we want to scrap this altogether and create a better demo?
