### PR TITLE
changed class usage in comment to match code

### DIFF
--- a/java/datastore/src/main/java/com/google/api/services/datastore/client/LocalDevelopmentDatastore.java
+++ b/java/datastore/src/main/java/com/google/api/services/datastore/client/LocalDevelopmentDatastore.java
@@ -56,12 +56,12 @@ import java.util.concurrent.TimeUnit;
  *
  *   {@literal @}Before
  *   public void setUp() throws LocalDevelopmentDatastoreException {
- *     datastore.clearDatastore();
+ *     datastore.clear();
  *   }
  *
  *   {@literal @}AfterClass
  *   public static void stopLocalDatastore() throws LocalDevelopmentDatastoreException {
- *     datastore.stopDatastore();
+ *     datastore.stop();
  *   }
  *
  *   {@literal @}Test


### PR DESCRIPTION
In the class comment, the example code was invoking the wrong methods:

datastore.stopDatastore()  is named  datastore.stop()  
datastore.clearDatastore()  is named datastore.clear()