### PR TITLE
python: accept .json as DATASTORE_PRIVATE_KEY_FILE

### DIFF
--- a/python/googledatastore/helper.py
+++ b/python/googledatastore/helper.py
@@ -17,6 +17,7 @@
 
 import calendar
 import datetime
+import json
 import logging
 import os
 
@@ -78,6 +79,8 @@ def get_credentials_from_env():
         and os.getenv('DATASTORE_PRIVATE_KEY_FILE')):
       with open(os.getenv('DATASTORE_PRIVATE_KEY_FILE'), 'rb') as f:
         key = f.read()
+      if os.getenv("DATASTORE_PRIVATE_KEY_FILE").endswith(".json"):
+        key = json.loads(key)["private_key"]
       credentials = client.SignedJwtAssertionCredentials(
           os.getenv('DATASTORE_SERVICE_ACCOUNT'), key, connection.SCOPE)
       logging.info('connect using DatastoreSignedJwtCredentials')


### PR DESCRIPTION
The instructions at
https://cloud.google.com/datastore/docs/getstarted/start_python/ lead
one to create a JSON keyfile, but the code didn't actually accept that.
This is a quick hack that just looks at the filename to decide whether
it is a raw key (PKCS#12?) or a JSON-wrapped one, and extract the key
from the JSON file if necessary.