### PR TITLE
v1beta2-rev1-3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pip install googledatastore
 <dependency>
   <groupId>com.google.apis</groupId>
   <artifactId>google-api-services-datastore-protobuf</artifactId>
-  <version>v1beta2-rev1-2.1.0</version>
+  <version>v1beta2-rev1-3.0.0</version>
 </dependency>
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,21 @@
 RELEASE NOTES
 =============
 
+v1beta2-rev1-3.0.0
+------------------
+- Change to QuerySplitter interface.
+  - This will not affect users of the interface, however is a breaking change for
+    any implements of the interface. This adds a method that allows specifying
+    the PartitionId so that namespace queries can be split.
+
+v1beta2-rev1-2.1.2
+------------------
+- Modify helper functions in the Python client library to support long integers.
+  - Fixes: https://github.com/GoogleCloudPlatform/google-cloud-datastore/issues/49.
+- Check environment variables before creating a Compute Engine credential in Python and Java client libraries.
+  - Fixes: https://github.com/GoogleCloudPlatform/google-cloud-datastore/issues/37.
+- Bring LocalDevelopmentDatastore into sync with the current `gcd` command line tool options.
+
 v1beta2-rev1-2.1.1
 ------------------
 - Update to latest App Engine SDK version.

--- a/java/datastore-shade/pom.xml
+++ b/java/datastore-shade/pom.xml
@@ -10,7 +10,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-datastore-protobuf</artifactId>
-      <version>v1beta2-rev1-2.1.0</version>
+      <version>v1beta2-rev1-3.0.0</version>
     </dependency>
   </dependencies>
   <build>
@@ -28,6 +28,6 @@
   <parent>
     <groupId>com.google.apis</groupId>
     <artifactId>google-api-services-datastore-protobuf-parent</artifactId>
-    <version>v1beta2-rev1-2.1.0</version>
+    <version>v1beta2-rev1-3.0.0</version>
   </parent>
 </project>

--- a/java/datastore/pom.xml
+++ b/java/datastore/pom.xml
@@ -70,6 +70,6 @@
   <parent>
     <groupId>com.google.apis</groupId>
     <artifactId>google-api-services-datastore-protobuf-parent</artifactId>
-    <version>v1beta2-rev1-2.1.0</version>
+    <version>v1beta2-rev1-3.0.0</version>
   </parent>
 </project>

--- a/java/datastore/src/main/java/com/google/api/services/datastore/client/BaseDatastoreFactory.java
+++ b/java/datastore/src/main/java/com/google/api/services/datastore/client/BaseDatastoreFactory.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2013 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.services.datastore.client;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+
+import java.util.Arrays;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
+
+/**
+ * Client factory for {@link Datastore}.
+ *
+ */
+abstract class BaseDatastoreFactory<T> {
+
+  // Non-javadoc.
+  // This class allows RemoteRpc to be used by factory implementations defined
+  // outside of this package.
+  public static class RemoteRpc
+      extends com.google.api.services.datastore.client.RemoteRpc {
+    public RemoteRpc(HttpRequestFactory client, HttpRequestInitializer initializer, String url) {
+      super(client, initializer, url);
+    }
+  }
+
+  private static final Logger logger = Logger.getLogger(BaseDatastoreFactory.class.getName());
+
+  // Lazy load this because we might be running inside App Engine and this
+  // class isn't on the whitelist.
+  private static ConsoleHandler methodHandler;
+
+  protected abstract String buildUrl(DatastoreOptions options, String overrideUrl);
+  public abstract T create(DatastoreOptions options) throws IllegalArgumentException;
+
+  // TODO(user): Support something other than console handler for when we're
+  // running in App Engine
+  private static synchronized StreamHandler getStreamHandler() {
+    if (methodHandler == null) {
+      methodHandler = new ConsoleHandler();
+      methodHandler.setFormatter(new Formatter() {
+        @Override
+        public String format(LogRecord record) {
+          return record.getMessage() + "\n";
+        }
+      });
+      methodHandler.setLevel(Level.FINE);
+    }
+    return methodHandler;
+  }
+
+  protected BaseDatastoreFactory() { }
+
+  protected RemoteRpc
+      newRemoteRpc(DatastoreOptions options) {
+    return newRemoteRpc(options, System.getenv("DATASTORE_URL_INTERNAL_OVERRIDE"));
+  }
+
+  protected RemoteRpc newRemoteRpc(DatastoreOptions options, String  urlOverride) {
+    if (options == null) {
+      throw new IllegalArgumentException("options not set");
+    }
+    HttpRequestFactory client = makeClient(options);
+    return new RemoteRpc(client, options.getInitializer(), buildUrl(options, urlOverride));
+  }
+
+  /**
+   * Constructs a Google APIs HTTP client with the associated credentials.
+   */
+  public HttpRequestFactory makeClient(DatastoreOptions options) {
+    Credential credential = options.getCredential();
+    if (credential == null) {
+      logger.warning("Not using any credentials");
+    }
+    HttpTransport transport = options.getTransport();
+    if (transport == null) {
+      transport = credential == null ? new NetHttpTransport() : credential.getTransport();
+    }
+    return transport.createRequestFactory(credential);
+  }
+
+  /**
+   * Starts logging datastore method calls to the console. (Useful within tests.)
+   */
+  public static void logMethodCalls() {
+    Logger logger = Logger.getLogger(Datastore.class.getName());
+    logger.setLevel(Level.FINE);
+    if (!Arrays.asList(logger.getHandlers()).contains(getStreamHandler())) {
+      logger.addHandler(getStreamHandler());
+    }
+  }
+}

--- a/java/datastore/src/main/java/com/google/api/services/datastore/client/DatastoreFactory.java
+++ b/java/datastore/src/main/java/com/google/api/services/datastore/client/DatastoreFactory.java
@@ -15,67 +15,22 @@
  */
 package com.google.api.services.datastore.client;
 
-import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.http.HttpRequestFactory;
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.javanet.NetHttpTransport;
-
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Formatter;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
-import java.util.logging.StreamHandler;
 
 /**
  * Client factory for {@link Datastore}.
  *
  */
-public class DatastoreFactory {
-  private static final Logger logger = Logger.getLogger(DatastoreFactory.class.getName());
-
+public class DatastoreFactory extends BaseDatastoreFactory<Datastore>{
   /** Singleton factory instance. */
   private static final DatastoreFactory INSTANCE = new DatastoreFactory();
-
+  
   /** API version. */
   public static final String VERSION = "v1beta2";
 
-  // Lazy load this because we might be running inside App Engine and this
-  // class isn't on the whitelist.
-  private static ConsoleHandler methodHandler;
-
   public static DatastoreFactory get() {
     return INSTANCE;
-  }
-
-  // TODO(user): Support something other than console handler for when we're
-  // running in App Engine
-  private static synchronized StreamHandler getStreamHandler() {
-    if (methodHandler == null) {
-      methodHandler = new ConsoleHandler();
-      methodHandler.setFormatter(new Formatter() {
-        @Override
-        public String format(LogRecord record) {
-          return record.getMessage() + "\n";
-        }
-      });
-      methodHandler.setLevel(Level.FINE);
-    }
-    return methodHandler;
-  }
-
-  DatastoreFactory() { }
-
-  RemoteRpc newRemoteRpc(DatastoreOptions options) {
-    if (options == null) {
-      throw new IllegalArgumentException("options not set");
-    }
-    HttpRequestFactory client = makeClient(options);
-    return new RemoteRpc(client, options.getInitializer(),
-        buildUrl(options, System.getenv("DATASTORE_URL_INTERNAL_OVERRIDE")));
   }
 
   /**
@@ -85,27 +40,16 @@ public class DatastoreFactory {
    *
    * @throws IllegalArgumentException if the server or credentials weren't provided.
    */
+  @Override
   public Datastore create(DatastoreOptions options) throws IllegalArgumentException {
     return new Datastore(newRemoteRpc(options));
-  }
-
-  /**
-   * Constructs a Google APIs HTTP client with the associated credentials.
-   */
-  public HttpRequestFactory makeClient(DatastoreOptions options) {
-    Credential credential = options.getCredential();
-    if (credential == null) {
-      logger.warning("Not using any credentials");
-      return new NetHttpTransport().createRequestFactory();
-    }
-    HttpTransport transport = credential.getTransport();
-    return transport.createRequestFactory(credential);
   }
 
    /**
    * Build a valid datastore URL.
    */
-  String buildUrl(DatastoreOptions options, String overrideUrl) {
+  @Override
+  protected String buildUrl(DatastoreOptions options, String overrideUrl) {
     try {
       if (options.getDataset() == null) {
         throw new IllegalArgumentException("datastore dataset not set in options");
@@ -120,17 +64,6 @@ public class DatastoreFactory {
       return new URI(url).toString();
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException(e);
-    }
-  }
-
-  /**
-   * Starts logging datastore method calls to the console. (Useful within tests.)
-   */
-  public static void logMethodCalls() {
-    Logger logger = Logger.getLogger(Datastore.class.getName());
-    logger.setLevel(Level.FINE);
-    if (!Arrays.asList(logger.getHandlers()).contains(getStreamHandler())) {
-      logger.addHandler(getStreamHandler());
     }
   }
 }

--- a/java/datastore/src/main/java/com/google/api/services/datastore/client/DatastoreHelper.java
+++ b/java/datastore/src/main/java/com/google/api/services/datastore/client/DatastoreHelper.java
@@ -25,6 +25,7 @@ import com.google.api.services.datastore.DatastoreV1.CompositeFilter;
 import com.google.api.services.datastore.DatastoreV1.Entity;
 import com.google.api.services.datastore.DatastoreV1.EntityOrBuilder;
 import com.google.api.services.datastore.DatastoreV1.Filter;
+import com.google.api.services.datastore.DatastoreV1.GeoPoint;
 import com.google.api.services.datastore.DatastoreV1.Key;
 import com.google.api.services.datastore.DatastoreV1.Key.PathElement;
 import com.google.api.services.datastore.DatastoreV1.Property;
@@ -39,7 +40,9 @@ import com.google.protobuf.ByteString;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -53,7 +56,7 @@ import java.util.logging.Logger;
  * Helper methods for {@link Datastore}.
  *
  */
-public class DatastoreHelper {
+public final class DatastoreHelper {
   private static final Logger logger = Logger.getLogger(DatastoreHelper.class.getName());
 
   /** The property used in the Datastore to give us a random distribution. **/
@@ -139,53 +142,103 @@ public class DatastoreHelper {
    */
   public static Credential getServiceAccountCredential(String account, String privateKeyFile)
       throws GeneralSecurityException, IOException {
+    return getServiceAccountCredential(account, privateKeyFile, DatastoreOptions.SCOPES);
+  }
+
+  /**
+   * Constructs credentials for the given account and key file.
+   *
+   * @param account the account to use.
+   * @param privateKeyFile the file name from which to get the private key.
+   * @param serviceAccountScopes Collection of OAuth scopes to use with the the service
+   *        account flow or {@code null} if not.
+   * @return valid credentials or {@code null}
+   */
+  public static Credential getServiceAccountCredential(String account, String privateKeyFile,
+      Collection<String> serviceAccountScopes) throws GeneralSecurityException, IOException {
+    return getCredentialBuilderWithoutPrivateKey(account, serviceAccountScopes)
+        .setServiceAccountPrivateKeyFromP12File(new File(privateKeyFile))
+        .build();
+  }
+
+  /**
+   * Constructs credentials for the given account and key.
+   *
+   * @param account the account to use.
+   * @param privateKey the private key for the given account.
+   * @param serviceAccountScopes Collection of OAuth scopes to use with the the service
+   *        account flow or {@code null} if not.
+   * @return valid credentials or {@code null}
+   */
+  public static Credential getServiceAccountCredential(String account, PrivateKey privateKey,
+      Collection<String> serviceAccountScopes) throws GeneralSecurityException, IOException {
+    return getCredentialBuilderWithoutPrivateKey(account, serviceAccountScopes)
+        .setServiceAccountPrivateKey(privateKey)
+        .build();
+  }
+
+  private static GoogleCredential.Builder getCredentialBuilderWithoutPrivateKey(
+      String account, Collection<String> scopes) throws GeneralSecurityException, IOException {
     NetHttpTransport transport = GoogleNetHttpTransport.newTrustedTransport();
     JacksonFactory jsonFactory = new JacksonFactory();
     return new GoogleCredential.Builder()
         .setTransport(transport)
         .setJsonFactory(jsonFactory)
         .setServiceAccountId(account)
-        .setServiceAccountScopes(DatastoreOptions.SCOPES)
-        .setServiceAccountPrivateKeyFromP12File(new File(privateKeyFile))
-        .build();
+        .setServiceAccountScopes(scopes);
   }
 
   /**
-   * Uses the following enviorment variables to construct a {@link Datastore}:
+   * @deprecated Use {@link #getOptionsFromEnv()}.
+   */
+  @Deprecated
+  // TODO(user): Remove in the next major version of the client libs.
+  public static DatastoreOptions.Builder getOptionsfromEnv()
+      throws GeneralSecurityException, IOException {
+    return getOptionsFromEnv();
+  }
+
+  /**
+   * Uses the following environment variables to construct a {@link Datastore}:
    *  DATASTORE_DATASET - the datastore dataset id
    *  DATASTORE_HOST - the host to use to access the datastore
-   *    e.g: https://www.googleapis.com/datastore/v1/datasets/{dataset}
+   *    e.g: https://www.googleapis.com
    *  DATASTORE_SERVICE_ACCOUNT - (optional) service account name
    *  DATASTORE_PRIVATE_KEY_FILE - (optional) service account private key file
    *
    * Preference of credentials is:
-   *  - ComputeEngine
    *  - Service Account (specified by DATASTORE_SERVICE_ACCOUNT and DATASTORE_PRIVATE_KEY_FILE)
+   *  - ComputeEngine
    *  - no-credentials (for local development environment)
    */
-  public static DatastoreOptions.Builder getOptionsfromEnv()
+  public static DatastoreOptions.Builder getOptionsFromEnv()
       throws GeneralSecurityException, IOException {
     DatastoreOptions.Builder options = new DatastoreOptions.Builder();
     options.dataset(System.getenv("DATASTORE_DATASET"));
     options.host(System.getenv("DATASTORE_HOST"));
-    Credential credential = getComputeEngineCredential();
-    if (credential != null) {
-      logger.info("Using Compute Engine credential.");
-    } else if (System.getenv("DATASTORE_SERVICE_ACCOUNT") != null &&
-        System.getenv("DATASTORE_PRIVATE_KEY_FILE") != null) {
+    Credential credential;
+    if (System.getenv("DATASTORE_SERVICE_ACCOUNT") != null
+        && System.getenv("DATASTORE_PRIVATE_KEY_FILE") != null) {
       credential = getServiceAccountCredential(System.getenv("DATASTORE_SERVICE_ACCOUNT"),
           System.getenv("DATASTORE_PRIVATE_KEY_FILE"));
       logger.info("Using JWT Service Account credential.");
+    } else {
+      credential = getComputeEngineCredential();
+      if (credential != null) {
+        logger.info("Using Compute Engine credential.");
+      } else {
+        logger.info("Using no credential.");
+      }
     }
     options.credential(credential);
     return options;
   }
 
   /**
-   * @see #getOptionsfromEnv()
+   * @see #getOptionsFromEnv()
    */
   public static Datastore getDatastoreFromEnv() throws GeneralSecurityException, IOException {
-    return DatastoreFactory.get().create(getOptionsfromEnv().build());
+    return DatastoreFactory.get().create(getOptionsFromEnv().build());
   }
 
   /**
@@ -328,7 +381,7 @@ public class DatastoreHelper {
   }
 
   /**
-   * Make a floating point value.
+   * Make a boolean value.
    */
   public static Value.Builder makeValue(boolean value) {
     return Value.newBuilder().setBooleanValue(value);
@@ -342,7 +395,7 @@ public class DatastoreHelper {
   }
 
   /**
-   * Make a key value.
+   * Make an entity value.
    */
   public static Value.Builder makeValue(Entity entity) {
     return Value.newBuilder().setEntityValue(entity);
@@ -356,7 +409,7 @@ public class DatastoreHelper {
   }
 
   /**
-   * Make a entity value.
+   * Make a ByteString value.
    */
   public static Value.Builder makeValue(ByteString blob) {
     return Value.newBuilder().setBlobValue(blob);
@@ -367,6 +420,20 @@ public class DatastoreHelper {
    */
   public static Value.Builder makeValue(Date date) {
     return Value.newBuilder().setTimestampMicrosecondsValue(date.getTime() * 1000L);
+  }
+
+  /**
+   * Makes a GeoPoint value.
+   */
+  public static Value.Builder makeValue(GeoPoint value) {
+    return Value.newBuilder().setGeoPointValue(value);
+  }
+
+  /**
+   * Makes a GeoPoint value.
+   */
+  public static Value.Builder makeValue(GeoPoint.Builder value) {
+    return makeValue(value.build());
   }
 
   /**

--- a/java/datastore/src/main/java/com/google/api/services/datastore/client/DatastoreOptions.java
+++ b/java/datastore/src/main/java/com/google/api/services/datastore/client/DatastoreOptions.java
@@ -17,19 +17,21 @@ package com.google.api.services.datastore.client;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
 
 import java.util.Arrays;
 import java.util.List;
 
 /**
- * A mutable object containing settings for the datastore.
+ * An immutable object containing settings for the datastore.
  *
  * <p>Example for connecting to a datastore:</p>
  *
  * <pre>
- * DatastoreOptions options = new DatastoreOptions()
- *     .dataset("my-dataset-id"),
- *     .credential(DatastoreHelper.getGceCredential());
+ * DatastoreOptions options = new DatastoreOptions.Builder()
+ *     .dataset("my-dataset-id")
+ *     .credential(DatastoreHelper.getComputeEngineCredential())
+ *     .build();
  * DatastoreFactory.get().create(options);
  * </pre>
  *
@@ -46,16 +48,17 @@ public class DatastoreOptions {
   private final HttpRequestInitializer initializer;
 
   private final Credential credential;
+  private final HttpTransport transport;
   public static final List<String> SCOPES = Arrays.asList(
       "https://www.googleapis.com/auth/datastore",
       "https://www.googleapis.com/auth/userinfo.email");
 
-  DatastoreOptions(String dataset, String host, HttpRequestInitializer initializer,
-      Credential credential) {
-    this.dataset = dataset;
-    this.host = host != null ? host : DEFAULT_HOST;
-    this.initializer = initializer;
-    this.credential = credential;
+  DatastoreOptions(Builder b) {
+    this.dataset = b.dataset;
+    this.host = b.host != null ? b.host : DEFAULT_HOST;
+    this.initializer = b.initializer;
+    this.credential = b.credential;
+    this.transport = b.transport;
   }
 
   /**
@@ -66,6 +69,7 @@ public class DatastoreOptions {
     private String host;
     private HttpRequestInitializer initializer;
     private Credential credential;
+    private HttpTransport transport;
 
     public Builder() { }
 
@@ -74,10 +78,11 @@ public class DatastoreOptions {
       this.host = options.host;
       this.initializer = options.initializer;
       this.credential = options.credential;
+      this.transport = options.transport;
     }
 
     public DatastoreOptions build() {
-      return new DatastoreOptions(dataset, host, initializer, credential);
+      return new DatastoreOptions(this);
     }
 
     /**
@@ -111,6 +116,14 @@ public class DatastoreOptions {
       credential = newCredential;
       return this;
     }
+    
+    /**
+     * Sets the transport used to access the API.
+     */
+    public Builder transport(HttpTransport transport) {
+      this.transport = transport;
+      return this;
+    }
   }
 
   // === getters ===
@@ -129,5 +142,9 @@ public class DatastoreOptions {
 
   public Credential getCredential() {
     return credential;
+  }
+  
+  public HttpTransport getTransport() {
+    return transport;
   }
 }

--- a/java/datastore/src/main/java/com/google/api/services/datastore/client/LocalDevelopmentDatastoreFactory.java
+++ b/java/datastore/src/main/java/com/google/api/services/datastore/client/LocalDevelopmentDatastoreFactory.java
@@ -35,7 +35,13 @@ public class LocalDevelopmentDatastoreFactory extends DatastoreFactory {
   @Override
   public LocalDevelopmentDatastore create(DatastoreOptions options)
       throws IllegalArgumentException {
+    return create(options, new LocalDevelopmentDatastoreOptions.Builder().build());
+  }
+
+  public LocalDevelopmentDatastore create(DatastoreOptions options,
+      LocalDevelopmentDatastoreOptions localDevelopmentOptions) {
     RemoteRpc rpc = newRemoteRpc(options);
-    return new LocalDevelopmentDatastore(rpc, options.getHost());
+    return new LocalDevelopmentDatastore(rpc, options.getHost(),
+        localDevelopmentOptions);
   }
 }

--- a/java/datastore/src/main/java/com/google/api/services/datastore/client/LocalDevelopmentDatastoreOptions.java
+++ b/java/datastore/src/main/java/com/google/api/services/datastore/client/LocalDevelopmentDatastoreOptions.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.services.datastore.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An immutable object containing settings for a {@link LocalDevelopmentDatastore}.
+ */
+public class LocalDevelopmentDatastoreOptions {
+  private final Map<String, String> envVars;
+  
+  LocalDevelopmentDatastoreOptions(Map<String, String> envVars) {
+    this.envVars = envVars;
+  }
+  
+  /**
+   * Builder for {@link LocalDevelopmentDatastoreOptions}.
+   */
+  public static class Builder {
+    private final Map<String, String> envVars = new HashMap<String, String>();
+
+    public LocalDevelopmentDatastoreOptions build() {
+      return new LocalDevelopmentDatastoreOptions(envVars);
+    }
+    
+    /**
+     * Adds an environment variable to pass to the GCD tool.
+     */
+    public Builder addEnvVar(String var, String value) {
+      envVars.put(var, value);
+      return this;
+    }
+  }
+  
+  public Map<String, String> getEnvVars() {
+    return envVars;
+  }
+}

--- a/java/datastore/src/main/java/com/google/api/services/datastore/client/QuerySplitter.java
+++ b/java/datastore/src/main/java/com/google/api/services/datastore/client/QuerySplitter.java
@@ -15,6 +15,7 @@
  */
 package com.google.api.services.datastore.client;
 
+import com.google.api.services.datastore.DatastoreV1.PartitionId;
 import com.google.api.services.datastore.DatastoreV1.Query;
 
 import java.util.List;
@@ -38,7 +39,27 @@ public interface QuerySplitter {
    * @param datastore the datastore to run on.
    * @throws DatastoreException if there was a datastore error while generating query splits.
    * @throws IllegalArgumentException if the given query or numSplits was invalid.
+   * @deprecated Use {@link getSplits(Query, PartitionId, int, Datastore)} instead, which provides
+   *     the ability to supply a namespace.
    */
-  List<Query> getSplits(Query query, int numSplits, Datastore datastore)
+  @Deprecated
+  List<Query> getSplits(Query query, int numSplits, Datastore datastore) throws DatastoreException;
+
+  /**
+   * Returns a list of sharded {@link Query}s for the given query.
+   *
+   * <p>This will create up to the desired number of splits, however it may return less splits if
+   * the desired number of splits is unavailable. This will happen if the number of split points
+   * provided by the underlying Datastore is less than the desired number, which will occur if the
+   * number of results for the query is too small.
+   *
+   * @param query the query to split.
+   * @param partition the partition to run in.
+   * @param numSplits the desired number of splits.
+   * @param datastore the datastore to run on.
+   * @throws DatastoreException if there was a datastore error while generating query splits.
+   * @throws IllegalArgumentException if the given query or numSplits was invalid.
+   */
+  List<Query> getSplits(Query query, PartitionId partition, int numSplits, Datastore datastore)
       throws DatastoreException;
 }

--- a/java/demos-shade/pom.xml
+++ b/java/demos-shade/pom.xml
@@ -10,7 +10,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-datastore-protobuf-demos</artifactId>
-      <version>v1beta2-rev1-2.1.0</version>
+      <version>v1beta2-rev1-3.0.0</version>
     </dependency>
   </dependencies>
   <build>
@@ -39,6 +39,6 @@
   <parent>
     <groupId>com.google.apis</groupId>
     <artifactId>google-api-services-datastore-protobuf-parent</artifactId>
-    <version>v1beta2-rev1-2.1.0</version>
+    <version>v1beta2-rev1-3.0.0</version>
   </parent>
 </project>

--- a/java/demos/pom.xml
+++ b/java/demos/pom.xml
@@ -10,7 +10,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-datastore-protobuf</artifactId>
-      <version>v1beta2-rev1-2.1.0</version>
+      <version>v1beta2-rev1-3.0.0</version>
     </dependency>
   </dependencies>
   <build>
@@ -32,6 +32,6 @@
   <parent>
     <groupId>com.google.apis</groupId>
     <artifactId>google-api-services-datastore-protobuf-parent</artifactId>
-    <version>v1beta2-rev1-2.1.0</version>
+    <version>v1beta2-rev1-3.0.0</version>
   </parent>
 </project>

--- a/java/demos/src/main/java/com/google/api/services/datastore/demos/trivial/Adams.java
+++ b/java/demos/src/main/java/com/google/api/services/datastore/demos/trivial/Adams.java
@@ -41,7 +41,7 @@ public class Adams {
     try {
       // Setup the connection to Google Cloud Datastore and infer credentials
       // from the environment.
-      datastore = DatastoreFactory.get().create(DatastoreHelper.getOptionsfromEnv()
+      datastore = DatastoreFactory.get().create(DatastoreHelper.getOptionsFromEnv()
           .dataset(datasetId).build());
     } catch (GeneralSecurityException exception) {
       System.err.println("Security error connecting to the datastore: " + exception.getMessage());

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>google-api-services-datastore-protobuf-parent</artifactId>
   <packaging>pom</packaging>
   <name>google-api-services-datastore-protobuf-parent</name>
-  <version>v1beta2-rev1-2.1.0</version>
+  <version>v1beta2-rev1-3.0.0</version>
   <modules>
     <module>datastore</module>
     <module>demos</module>
@@ -27,8 +27,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>2.5.1</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.7</source>
+            <target>1.7</target>
           </configuration>
         </plugin>
         <plugin>

--- a/nodejs/demos/todos/todo.js
+++ b/nodejs/demos/todos/todo.js
@@ -67,7 +67,7 @@ var commands = {
       }]
     }).execute(function(err, result) {
       console.assert(!err, err);
-      console.assert(!result.missing, 'todo %d: not found', id);
+      console.assert(result.found.length > 0, 'todo %d: not found', id);
       var entity = result.found[0].entity;
       var title = entity.properties.title.values[0].stringValue;
       var completed = entity.properties.completed.values[0].booleanValue == true;

--- a/proto/datastore_v1.proto
+++ b/proto/datastore_v1.proto
@@ -35,7 +35,7 @@ option java_package = "com.google.api.services.datastore";
 // Dataset ID:
 // A dataset id's value must never be "".
 // A dataset id's value must match
-// ([a-z\d\-]{1,100}~)?([a-z\d][a-z\d\-\.]{0,99}:)?([a-z\d][a-z\d\-]{0,99}
+// ([a-z\d\-]{1,100}~)?([a-z\d][a-z\d\-\.]{0,99}\:)?([a-z\d][a-z\d\-]{0,99})
 message PartitionId {
   // The dataset ID.
   optional string dataset_id = 3;
@@ -86,8 +86,21 @@ message Key {
   // are required to be in the path along with the entity identifier itself.
   // The only exception is that in some documented cases, the identifier in the
   // last path element (for the entity) itself may be omitted. A path can never
-  // be empty.
+  // be empty. The path can have at most 100 elements.
   repeated PathElement path_element = 2;
+}
+
+// A geospatial point on the surface of Earth.
+//
+// A GeoPoint is represented by a latitude and a longitude in decimal degrees.
+message GeoPoint {
+  // The geo point's latitude in decimal degrees.
+  // Latitude must be between -90 and 90.
+  required double latitude = 1;
+
+  // The geo point's longitude in decimal degrees.
+  // Longitude must be between -180 and 180.
+  required double longitude = 2;
 }
 
 // A message that can hold any of the supported value types and associated
@@ -110,9 +123,15 @@ message Value {
   // A blob key value.
   optional string blob_key_value = 16;
   // A UTF-8 encoded string value.
+  // When indexed is true, may have at most 500 characters.
+  // (But see exception below.)
   optional string string_value = 17;
   // A blob value.
+  // May be a maximum of 1,000,000 bytes.
+  // When indexed is true, may have at most 500 bytes.
   optional bytes blob_value = 18;
+  // A geo point value representing a point on the surface of Earth.
+  optional GeoPoint geo_point_value = 8;
   // An entity value.
   // May have no key.
   // May have a key with an incomplete key path.
@@ -120,7 +139,8 @@ message Value {
   optional Entity entity_value = 6;
   // A list value.
   // Cannot contain another list value.
-  // Cannot also have a meaning and indexing set.
+  // A Value instance that sets field list_value must not set
+  // field meaning or field indexed.
   repeated Value list_value = 7;
 
   // The <code>meaning</code> field is reserved and should not be used.
@@ -132,7 +152,7 @@ message Value {
   // <code>null</code> value.
   // When <code>indexed</code> is <code>true</code>, <code>stringValue</code>
   // is limited to 500 characters and the blob value is limited to 500 bytes.
-  // Exception: If meaning is set to 2, string_value is limited to 2038
+  // Exception: If meaning is set to 2, string_value is limited to 2083
   // characters regardless of indexed.
   // When indexed is true, meaning 15 and 22 are not allowed, and meaning 16
   // will be ignored on input (and will never be set on output).
@@ -198,6 +218,10 @@ message EntityResult {
 
   // The resulting entity.
   required Entity entity = 1;
+  optional int64 version = 2;
+  // A cursor that points to the position after the result entity.
+  // Set only when the EntityResult is part of a QueryResultBatch message.
+  optional bytes cursor = 3;
 }
 
 // A query.
@@ -220,11 +244,11 @@ message Query {
 
   // A starting point for the query results. Optional. Query cursors are
   // returned in query result batches.
-  optional bytes /* serialized QueryCursor */ start_cursor = 7;
+  optional bytes start_cursor = 7;
 
   // An ending point for the query results. Optional. Query cursors are
   // returned in query result batches.
-  optional bytes /* serialized QueryCursor */ end_cursor = 8;
+  optional bytes end_cursor = 8;
 
   // The number of results to skip. Applies before limit, but after all other
   // constraints (optional, defaults to 0).
@@ -317,6 +341,7 @@ message PropertyFilter {
 
 // A GQL query.
 message GqlQuery {
+  // The query string.
   required string query_string = 1;
   // When false, the query string must not contain a literal.
   optional bool allow_literal = 2 [default = false];
@@ -361,15 +386,20 @@ message QueryResultBatch {
   // The results for this batch.
   repeated EntityResult entity_result = 2;
 
+  // A cursor that points to the position after the last skipped result.
+  // Will be set when skipped_result != 0.
+  optional bytes skipped_cursor = 3;
   // A cursor that points to the position after the last result in the batch.
   // May be absent.
-  optional bytes /* serialized QueryCursor */ end_cursor = 4;
+  optional bytes end_cursor = 4;
 
   // The state of the query after the current batch.
   required MoreResultsType more_results = 5;
 
   // The number of results skipped because of <code>Query.offset</code>.
   optional int32 skipped_results = 6;
+
+  optional int64 snapshot_version = 7;
 }
 
 // A set of changes to apply.
@@ -429,7 +459,7 @@ message ReadOptions {
   optional ReadConsistency read_consistency = 1 [default=DEFAULT];
 
   // The transaction to use. Optional.
-  optional bytes /* serialized Transaction */ transaction = 2;
+  optional bytes transaction = 2;
 }
 
 // The request for Lookup.
@@ -511,7 +541,7 @@ message BeginTransactionRequest {
 message BeginTransactionResponse {
 
   // The transaction identifier (always present).
-  optional bytes /* serialized Transaction */ transaction = 1;
+  optional bytes transaction = 1;
 }
 
 // The request for Rollback.
@@ -519,7 +549,7 @@ message RollbackRequest {
 
   // The transaction identifier, returned by a call to
   // <code>beginTransaction</code>.
-  required bytes /* serialized Transaction */ transaction = 1;
+  required bytes transaction = 1;
 }
 
 // The response for Rollback.
@@ -537,11 +567,13 @@ message CommitRequest {
 
   // The transaction identifier, returned by a call to
   // <code>beginTransaction</code>. Must be set when mode is TRANSACTIONAL.
-  optional bytes /* serialized Transaction */ transaction = 1;
+  optional bytes transaction = 1;
   // The mutation to perform. Optional.
   optional Mutation mutation = 2;
   // The type of commit to perform. Either TRANSACTIONAL or NON_TRANSACTIONAL.
   optional Mode mode = 5 [default=TRANSACTIONAL];
+  // Ignore a user specified read-only period.
+  optional bool ignore_read_only = 7 [default = false];
 }
 
 // The response for Commit.

--- a/python/demos/trivial/adams.py
+++ b/python/demos/trivial/adams.py
@@ -25,6 +25,7 @@ import logging
 import sys
 
 import googledatastore as datastore
+from googledatastore.helper import *
 
 def main():
   # Set dataset id from command line argument.
@@ -80,10 +81,11 @@ def main():
     # Apply the insert mutation if the entity was not found and close
     # the transaction.
     datastore.commit(req)
+    props = get_property_dict(entity)
     # Get question property value.
-    question = entity.property[0].value.string_value
+    question = props['question'].string_value
     # Get answer property value.
-    answer = entity.property[1].value.integer_value
+    answer = props['answer'].integer_value
     # Print the question and read one line from stdin.
     print question
     result = raw_input('> ')

--- a/python/googledatastore/__init__.py
+++ b/python/googledatastore/__init__.py
@@ -46,7 +46,7 @@ def set_options(**kwargs):
 def get_default_connection():
   """Return the default datastore connection.
 
-  Defaults dataset to os.getenv('DATASTORE_DATASET'), host to
+  dataset defaults to helper.get_dataset_from_env(), host to
   os.getenv('DATASTORE_HOST'), and credentials to
   helper.get_credentials_from_env().
 

--- a/python/googledatastore/datastore_v1_pb2.py
+++ b/python/googledatastore/datastore_v1_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import descriptor_pb2
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='datastore_v1.proto',
   package='api.services.datastore',
-  serialized_pb='\n\x12\x64\x61tastore_v1.proto\x12\x16\x61pi.services.datastore\"4\n\x0bPartitionId\x12\x12\n\ndataset_id\x18\x03 \x01(\t\x12\x11\n\tnamespace\x18\x04 \x01(\t\"\xb6\x01\n\x03Key\x12\x39\n\x0cpartition_id\x18\x01 \x01(\x0b\x32#.api.services.datastore.PartitionId\x12=\n\x0cpath_element\x18\x02 \x03(\x0b\x32\'.api.services.datastore.Key.PathElement\x1a\x35\n\x0bPathElement\x12\x0c\n\x04kind\x18\x01 \x02(\t\x12\n\n\x02id\x18\x02 \x01(\x03\x12\x0c\n\x04name\x18\x03 \x01(\t\"\xf4\x02\n\x05Value\x12\x15\n\rboolean_value\x18\x01 \x01(\x08\x12\x15\n\rinteger_value\x18\x02 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x03 \x01(\x01\x12$\n\x1ctimestamp_microseconds_value\x18\x04 \x01(\x03\x12.\n\tkey_value\x18\x05 \x01(\x0b\x32\x1b.api.services.datastore.Key\x12\x16\n\x0e\x62lob_key_value\x18\x10 \x01(\t\x12\x14\n\x0cstring_value\x18\x11 \x01(\t\x12\x12\n\nblob_value\x18\x12 \x01(\x0c\x12\x34\n\x0c\x65ntity_value\x18\x06 \x01(\x0b\x32\x1e.api.services.datastore.Entity\x12\x31\n\nlist_value\x18\x07 \x03(\x0b\x32\x1d.api.services.datastore.Value\x12\x0f\n\x07meaning\x18\x0e \x01(\x05\x12\x15\n\x07indexed\x18\x0f \x01(\x08:\x04true\"F\n\x08Property\x12\x0c\n\x04name\x18\x01 \x02(\t\x12,\n\x05value\x18\x04 \x02(\x0b\x32\x1d.api.services.datastore.Value\"f\n\x06\x45ntity\x12(\n\x03key\x18\x01 \x01(\x0b\x32\x1b.api.services.datastore.Key\x12\x32\n\x08property\x18\x02 \x03(\x0b\x32 .api.services.datastore.Property\"t\n\x0c\x45ntityResult\x12.\n\x06\x65ntity\x18\x01 \x02(\x0b\x32\x1e.api.services.datastore.Entity\"4\n\nResultType\x12\x08\n\x04\x46ULL\x10\x01\x12\x0e\n\nPROJECTION\x10\x02\x12\x0c\n\x08KEY_ONLY\x10\x03\"\xec\x02\n\x05Query\x12>\n\nprojection\x18\x02 \x03(\x0b\x32*.api.services.datastore.PropertyExpression\x12\x34\n\x04kind\x18\x03 \x03(\x0b\x32&.api.services.datastore.KindExpression\x12.\n\x06\x66ilter\x18\x04 \x01(\x0b\x32\x1e.api.services.datastore.Filter\x12\x34\n\x05order\x18\x05 \x03(\x0b\x32%.api.services.datastore.PropertyOrder\x12;\n\x08group_by\x18\x06 \x03(\x0b\x32).api.services.datastore.PropertyReference\x12\x14\n\x0cstart_cursor\x18\x07 \x01(\x0c\x12\x12\n\nend_cursor\x18\x08 \x01(\x0c\x12\x11\n\x06offset\x18\n \x01(\x05:\x01\x30\x12\r\n\x05limit\x18\x0b \x01(\x05\"\x1e\n\x0eKindExpression\x12\x0c\n\x04name\x18\x01 \x02(\t\"!\n\x11PropertyReference\x12\x0c\n\x04name\x18\x02 \x02(\t\"\xd1\x01\n\x12PropertyExpression\x12;\n\x08property\x18\x01 \x02(\x0b\x32).api.services.datastore.PropertyReference\x12\\\n\x14\x61ggregation_function\x18\x02 \x01(\x0e\x32>.api.services.datastore.PropertyExpression.AggregationFunction\" \n\x13\x41ggregationFunction\x12\t\n\x05\x46IRST\x10\x01\"\xc7\x01\n\rPropertyOrder\x12;\n\x08property\x18\x01 \x02(\x0b\x32).api.services.datastore.PropertyReference\x12M\n\tdirection\x18\x02 \x01(\x0e\x32/.api.services.datastore.PropertyOrder.Direction:\tASCENDING\"*\n\tDirection\x12\r\n\tASCENDING\x10\x01\x12\x0e\n\nDESCENDING\x10\x02\"\x8c\x01\n\x06\x46ilter\x12\x41\n\x10\x63omposite_filter\x18\x01 \x01(\x0b\x32\'.api.services.datastore.CompositeFilter\x12?\n\x0fproperty_filter\x18\x02 \x01(\x0b\x32&.api.services.datastore.PropertyFilter\"\x9a\x01\n\x0f\x43ompositeFilter\x12\x42\n\x08operator\x18\x01 \x02(\x0e\x32\x30.api.services.datastore.CompositeFilter.Operator\x12.\n\x06\x66ilter\x18\x02 \x03(\x0b\x32\x1e.api.services.datastore.Filter\"\x13\n\x08Operator\x12\x07\n\x03\x41ND\x10\x01\"\xbb\x02\n\x0ePropertyFilter\x12;\n\x08property\x18\x01 \x02(\x0b\x32).api.services.datastore.PropertyReference\x12\x41\n\x08operator\x18\x02 \x02(\x0e\x32/.api.services.datastore.PropertyFilter.Operator\x12,\n\x05value\x18\x03 \x02(\x0b\x32\x1d.api.services.datastore.Value\"{\n\x08Operator\x12\r\n\tLESS_THAN\x10\x01\x12\x16\n\x12LESS_THAN_OR_EQUAL\x10\x02\x12\x10\n\x0cGREATER_THAN\x10\x03\x12\x19\n\x15GREATER_THAN_OR_EQUAL\x10\x04\x12\t\n\x05\x45QUAL\x10\x05\x12\x10\n\x0cHAS_ANCESTOR\x10\x0b\"\xae\x01\n\x08GqlQuery\x12\x14\n\x0cquery_string\x18\x01 \x02(\t\x12\x1c\n\rallow_literal\x18\x02 \x01(\x08:\x05\x66\x61lse\x12\x35\n\x08name_arg\x18\x03 \x03(\x0b\x32#.api.services.datastore.GqlQueryArg\x12\x37\n\nnumber_arg\x18\x04 \x03(\x0b\x32#.api.services.datastore.GqlQueryArg\"Y\n\x0bGqlQueryArg\x12\x0c\n\x04name\x18\x01 \x01(\t\x12,\n\x05value\x18\x02 \x01(\x0b\x32\x1d.api.services.datastore.Value\x12\x0e\n\x06\x63ursor\x18\x03 \x01(\x0c\"\xf1\x02\n\x10QueryResultBatch\x12K\n\x12\x65ntity_result_type\x18\x01 \x02(\x0e\x32/.api.services.datastore.EntityResult.ResultType\x12;\n\rentity_result\x18\x02 \x03(\x0b\x32$.api.services.datastore.EntityResult\x12\x12\n\nend_cursor\x18\x04 \x01(\x0c\x12N\n\x0cmore_results\x18\x05 \x02(\x0e\x32\x38.api.services.datastore.QueryResultBatch.MoreResultsType\x12\x17\n\x0fskipped_results\x18\x06 \x01(\x05\"V\n\x0fMoreResultsType\x12\x10\n\x0cNOT_FINISHED\x10\x01\x12\x1c\n\x18MORE_RESULTS_AFTER_LIMIT\x10\x02\x12\x13\n\x0fNO_MORE_RESULTS\x10\x03\"\x8e\x02\n\x08Mutation\x12.\n\x06upsert\x18\x01 \x03(\x0b\x32\x1e.api.services.datastore.Entity\x12.\n\x06update\x18\x02 \x03(\x0b\x32\x1e.api.services.datastore.Entity\x12.\n\x06insert\x18\x03 \x03(\x0b\x32\x1e.api.services.datastore.Entity\x12\x36\n\x0einsert_auto_id\x18\x04 \x03(\x0b\x32\x1e.api.services.datastore.Entity\x12+\n\x06\x64\x65lete\x18\x05 \x03(\x0b\x32\x1b.api.services.datastore.Key\x12\r\n\x05\x66orce\x18\x06 \x01(\x08\"`\n\x0eMutationResult\x12\x15\n\rindex_updates\x18\x01 \x02(\x05\x12\x37\n\x12insert_auto_id_key\x18\x02 \x03(\x0b\x32\x1b.api.services.datastore.Key\"\xb4\x01\n\x0bReadOptions\x12V\n\x10read_consistency\x18\x01 \x01(\x0e\x32\x33.api.services.datastore.ReadOptions.ReadConsistency:\x07\x44\x45\x46\x41ULT\x12\x13\n\x0btransaction\x18\x02 \x01(\x0c\"8\n\x0fReadConsistency\x12\x0b\n\x07\x44\x45\x46\x41ULT\x10\x00\x12\n\n\x06STRONG\x10\x01\x12\x0c\n\x08\x45VENTUAL\x10\x02\"t\n\rLookupRequest\x12\x39\n\x0cread_options\x18\x01 \x01(\x0b\x32#.api.services.datastore.ReadOptions\x12(\n\x03key\x18\x03 \x03(\x0b\x32\x1b.api.services.datastore.Key\"\xab\x01\n\x0eLookupResponse\x12\x33\n\x05\x66ound\x18\x01 \x03(\x0b\x32$.api.services.datastore.EntityResult\x12\x35\n\x07missing\x18\x02 \x03(\x0b\x32$.api.services.datastore.EntityResult\x12-\n\x08\x64\x65\x66\x65rred\x18\x03 \x03(\x0b\x32\x1b.api.services.datastore.Key\"\xea\x01\n\x0fRunQueryRequest\x12\x39\n\x0cread_options\x18\x01 \x01(\x0b\x32#.api.services.datastore.ReadOptions\x12\x39\n\x0cpartition_id\x18\x02 \x01(\x0b\x32#.api.services.datastore.PartitionId\x12,\n\x05query\x18\x03 \x01(\x0b\x32\x1d.api.services.datastore.Query\x12\x33\n\tgql_query\x18\x07 \x01(\x0b\x32 .api.services.datastore.GqlQuery\"K\n\x10RunQueryResponse\x12\x37\n\x05\x62\x61tch\x18\x01 \x01(\x0b\x32(.api.services.datastore.QueryResultBatch\"\xae\x01\n\x17\x42\x65ginTransactionRequest\x12\x61\n\x0fisolation_level\x18\x01 \x01(\x0e\x32>.api.services.datastore.BeginTransactionRequest.IsolationLevel:\x08SNAPSHOT\"0\n\x0eIsolationLevel\x12\x0c\n\x08SNAPSHOT\x10\x00\x12\x10\n\x0cSERIALIZABLE\x10\x01\"/\n\x18\x42\x65ginTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"&\n\x0fRollbackRequest\x12\x13\n\x0btransaction\x18\x01 \x02(\x0c\"\x12\n\x10RollbackResponse\"\xd3\x01\n\rCommitRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x32\n\x08mutation\x18\x02 \x01(\x0b\x32 .api.services.datastore.Mutation\x12G\n\x04mode\x18\x05 \x01(\x0e\x32*.api.services.datastore.CommitRequest.Mode:\rTRANSACTIONAL\"0\n\x04Mode\x12\x11\n\rTRANSACTIONAL\x10\x01\x12\x15\n\x11NON_TRANSACTIONAL\x10\x02\"Q\n\x0e\x43ommitResponse\x12?\n\x0fmutation_result\x18\x01 \x01(\x0b\x32&.api.services.datastore.MutationResult\">\n\x12\x41llocateIdsRequest\x12(\n\x03key\x18\x01 \x03(\x0b\x32\x1b.api.services.datastore.Key\"?\n\x13\x41llocateIdsResponse\x12(\n\x03key\x18\x01 \x03(\x0b\x32\x1b.api.services.datastore.Key2\xed\x04\n\x10\x44\x61tastoreService\x12Y\n\x06Lookup\x12%.api.services.datastore.LookupRequest\x1a&.api.services.datastore.LookupResponse\"\x00\x12_\n\x08RunQuery\x12\'.api.services.datastore.RunQueryRequest\x1a(.api.services.datastore.RunQueryResponse\"\x00\x12w\n\x10\x42\x65ginTransaction\x12/.api.services.datastore.BeginTransactionRequest\x1a\x30.api.services.datastore.BeginTransactionResponse\"\x00\x12Y\n\x06\x43ommit\x12%.api.services.datastore.CommitRequest\x1a&.api.services.datastore.CommitResponse\"\x00\x12_\n\x08Rollback\x12\'.api.services.datastore.RollbackRequest\x1a(.api.services.datastore.RollbackResponse\"\x00\x12h\n\x0b\x41llocateIds\x12*.api.services.datastore.AllocateIdsRequest\x1a+.api.services.datastore.AllocateIdsResponse\"\x00\x42#\n!com.google.api.services.datastore')
+  serialized_pb='\n\x12\x64\x61tastore_v1.proto\x12\x16\x61pi.services.datastore\"4\n\x0bPartitionId\x12\x12\n\ndataset_id\x18\x03 \x01(\t\x12\x11\n\tnamespace\x18\x04 \x01(\t\"\xb6\x01\n\x03Key\x12\x39\n\x0cpartition_id\x18\x01 \x01(\x0b\x32#.api.services.datastore.PartitionId\x12=\n\x0cpath_element\x18\x02 \x03(\x0b\x32\'.api.services.datastore.Key.PathElement\x1a\x35\n\x0bPathElement\x12\x0c\n\x04kind\x18\x01 \x02(\t\x12\n\n\x02id\x18\x02 \x01(\x03\x12\x0c\n\x04name\x18\x03 \x01(\t\"/\n\x08GeoPoint\x12\x10\n\x08latitude\x18\x01 \x02(\x01\x12\x11\n\tlongitude\x18\x02 \x02(\x01\"\xaf\x03\n\x05Value\x12\x15\n\rboolean_value\x18\x01 \x01(\x08\x12\x15\n\rinteger_value\x18\x02 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x03 \x01(\x01\x12$\n\x1ctimestamp_microseconds_value\x18\x04 \x01(\x03\x12.\n\tkey_value\x18\x05 \x01(\x0b\x32\x1b.api.services.datastore.Key\x12\x16\n\x0e\x62lob_key_value\x18\x10 \x01(\t\x12\x14\n\x0cstring_value\x18\x11 \x01(\t\x12\x12\n\nblob_value\x18\x12 \x01(\x0c\x12\x39\n\x0fgeo_point_value\x18\x08 \x01(\x0b\x32 .api.services.datastore.GeoPoint\x12\x34\n\x0c\x65ntity_value\x18\x06 \x01(\x0b\x32\x1e.api.services.datastore.Entity\x12\x31\n\nlist_value\x18\x07 \x03(\x0b\x32\x1d.api.services.datastore.Value\x12\x0f\n\x07meaning\x18\x0e \x01(\x05\x12\x15\n\x07indexed\x18\x0f \x01(\x08:\x04true\"F\n\x08Property\x12\x0c\n\x04name\x18\x01 \x02(\t\x12,\n\x05value\x18\x04 \x02(\x0b\x32\x1d.api.services.datastore.Value\"f\n\x06\x45ntity\x12(\n\x03key\x18\x01 \x01(\x0b\x32\x1b.api.services.datastore.Key\x12\x32\n\x08property\x18\x02 \x03(\x0b\x32 .api.services.datastore.Property\"\x95\x01\n\x0c\x45ntityResult\x12.\n\x06\x65ntity\x18\x01 \x02(\x0b\x32\x1e.api.services.datastore.Entity\x12\x0f\n\x07version\x18\x02 \x01(\x03\x12\x0e\n\x06\x63ursor\x18\x03 \x01(\x0c\"4\n\nResultType\x12\x08\n\x04\x46ULL\x10\x01\x12\x0e\n\nPROJECTION\x10\x02\x12\x0c\n\x08KEY_ONLY\x10\x03\"\xec\x02\n\x05Query\x12>\n\nprojection\x18\x02 \x03(\x0b\x32*.api.services.datastore.PropertyExpression\x12\x34\n\x04kind\x18\x03 \x03(\x0b\x32&.api.services.datastore.KindExpression\x12.\n\x06\x66ilter\x18\x04 \x01(\x0b\x32\x1e.api.services.datastore.Filter\x12\x34\n\x05order\x18\x05 \x03(\x0b\x32%.api.services.datastore.PropertyOrder\x12;\n\x08group_by\x18\x06 \x03(\x0b\x32).api.services.datastore.PropertyReference\x12\x14\n\x0cstart_cursor\x18\x07 \x01(\x0c\x12\x12\n\nend_cursor\x18\x08 \x01(\x0c\x12\x11\n\x06offset\x18\n \x01(\x05:\x01\x30\x12\r\n\x05limit\x18\x0b \x01(\x05\"\x1e\n\x0eKindExpression\x12\x0c\n\x04name\x18\x01 \x02(\t\"!\n\x11PropertyReference\x12\x0c\n\x04name\x18\x02 \x02(\t\"\xd1\x01\n\x12PropertyExpression\x12;\n\x08property\x18\x01 \x02(\x0b\x32).api.services.datastore.PropertyReference\x12\\\n\x14\x61ggregation_function\x18\x02 \x01(\x0e\x32>.api.services.datastore.PropertyExpression.AggregationFunction\" \n\x13\x41ggregationFunction\x12\t\n\x05\x46IRST\x10\x01\"\xc7\x01\n\rPropertyOrder\x12;\n\x08property\x18\x01 \x02(\x0b\x32).api.services.datastore.PropertyReference\x12M\n\tdirection\x18\x02 \x01(\x0e\x32/.api.services.datastore.PropertyOrder.Direction:\tASCENDING\"*\n\tDirection\x12\r\n\tASCENDING\x10\x01\x12\x0e\n\nDESCENDING\x10\x02\"\x8c\x01\n\x06\x46ilter\x12\x41\n\x10\x63omposite_filter\x18\x01 \x01(\x0b\x32\'.api.services.datastore.CompositeFilter\x12?\n\x0fproperty_filter\x18\x02 \x01(\x0b\x32&.api.services.datastore.PropertyFilter\"\x9a\x01\n\x0f\x43ompositeFilter\x12\x42\n\x08operator\x18\x01 \x02(\x0e\x32\x30.api.services.datastore.CompositeFilter.Operator\x12.\n\x06\x66ilter\x18\x02 \x03(\x0b\x32\x1e.api.services.datastore.Filter\"\x13\n\x08Operator\x12\x07\n\x03\x41ND\x10\x01\"\xbb\x02\n\x0ePropertyFilter\x12;\n\x08property\x18\x01 \x02(\x0b\x32).api.services.datastore.PropertyReference\x12\x41\n\x08operator\x18\x02 \x02(\x0e\x32/.api.services.datastore.PropertyFilter.Operator\x12,\n\x05value\x18\x03 \x02(\x0b\x32\x1d.api.services.datastore.Value\"{\n\x08Operator\x12\r\n\tLESS_THAN\x10\x01\x12\x16\n\x12LESS_THAN_OR_EQUAL\x10\x02\x12\x10\n\x0cGREATER_THAN\x10\x03\x12\x19\n\x15GREATER_THAN_OR_EQUAL\x10\x04\x12\t\n\x05\x45QUAL\x10\x05\x12\x10\n\x0cHAS_ANCESTOR\x10\x0b\"\xae\x01\n\x08GqlQuery\x12\x14\n\x0cquery_string\x18\x01 \x02(\t\x12\x1c\n\rallow_literal\x18\x02 \x01(\x08:\x05\x66\x61lse\x12\x35\n\x08name_arg\x18\x03 \x03(\x0b\x32#.api.services.datastore.GqlQueryArg\x12\x37\n\nnumber_arg\x18\x04 \x03(\x0b\x32#.api.services.datastore.GqlQueryArg\"Y\n\x0bGqlQueryArg\x12\x0c\n\x04name\x18\x01 \x01(\t\x12,\n\x05value\x18\x02 \x01(\x0b\x32\x1d.api.services.datastore.Value\x12\x0e\n\x06\x63ursor\x18\x03 \x01(\x0c\"\xa3\x03\n\x10QueryResultBatch\x12K\n\x12\x65ntity_result_type\x18\x01 \x02(\x0e\x32/.api.services.datastore.EntityResult.ResultType\x12;\n\rentity_result\x18\x02 \x03(\x0b\x32$.api.services.datastore.EntityResult\x12\x16\n\x0eskipped_cursor\x18\x03 \x01(\x0c\x12\x12\n\nend_cursor\x18\x04 \x01(\x0c\x12N\n\x0cmore_results\x18\x05 \x02(\x0e\x32\x38.api.services.datastore.QueryResultBatch.MoreResultsType\x12\x17\n\x0fskipped_results\x18\x06 \x01(\x05\x12\x18\n\x10snapshot_version\x18\x07 \x01(\x03\"V\n\x0fMoreResultsType\x12\x10\n\x0cNOT_FINISHED\x10\x01\x12\x1c\n\x18MORE_RESULTS_AFTER_LIMIT\x10\x02\x12\x13\n\x0fNO_MORE_RESULTS\x10\x03\"\x8e\x02\n\x08Mutation\x12.\n\x06upsert\x18\x01 \x03(\x0b\x32\x1e.api.services.datastore.Entity\x12.\n\x06update\x18\x02 \x03(\x0b\x32\x1e.api.services.datastore.Entity\x12.\n\x06insert\x18\x03 \x03(\x0b\x32\x1e.api.services.datastore.Entity\x12\x36\n\x0einsert_auto_id\x18\x04 \x03(\x0b\x32\x1e.api.services.datastore.Entity\x12+\n\x06\x64\x65lete\x18\x05 \x03(\x0b\x32\x1b.api.services.datastore.Key\x12\r\n\x05\x66orce\x18\x06 \x01(\x08\"`\n\x0eMutationResult\x12\x15\n\rindex_updates\x18\x01 \x02(\x05\x12\x37\n\x12insert_auto_id_key\x18\x02 \x03(\x0b\x32\x1b.api.services.datastore.Key\"\xb4\x01\n\x0bReadOptions\x12V\n\x10read_consistency\x18\x01 \x01(\x0e\x32\x33.api.services.datastore.ReadOptions.ReadConsistency:\x07\x44\x45\x46\x41ULT\x12\x13\n\x0btransaction\x18\x02 \x01(\x0c\"8\n\x0fReadConsistency\x12\x0b\n\x07\x44\x45\x46\x41ULT\x10\x00\x12\n\n\x06STRONG\x10\x01\x12\x0c\n\x08\x45VENTUAL\x10\x02\"t\n\rLookupRequest\x12\x39\n\x0cread_options\x18\x01 \x01(\x0b\x32#.api.services.datastore.ReadOptions\x12(\n\x03key\x18\x03 \x03(\x0b\x32\x1b.api.services.datastore.Key\"\xab\x01\n\x0eLookupResponse\x12\x33\n\x05\x66ound\x18\x01 \x03(\x0b\x32$.api.services.datastore.EntityResult\x12\x35\n\x07missing\x18\x02 \x03(\x0b\x32$.api.services.datastore.EntityResult\x12-\n\x08\x64\x65\x66\x65rred\x18\x03 \x03(\x0b\x32\x1b.api.services.datastore.Key\"\xea\x01\n\x0fRunQueryRequest\x12\x39\n\x0cread_options\x18\x01 \x01(\x0b\x32#.api.services.datastore.ReadOptions\x12\x39\n\x0cpartition_id\x18\x02 \x01(\x0b\x32#.api.services.datastore.PartitionId\x12,\n\x05query\x18\x03 \x01(\x0b\x32\x1d.api.services.datastore.Query\x12\x33\n\tgql_query\x18\x07 \x01(\x0b\x32 .api.services.datastore.GqlQuery\"K\n\x10RunQueryResponse\x12\x37\n\x05\x62\x61tch\x18\x01 \x01(\x0b\x32(.api.services.datastore.QueryResultBatch\"\xae\x01\n\x17\x42\x65ginTransactionRequest\x12\x61\n\x0fisolation_level\x18\x01 \x01(\x0e\x32>.api.services.datastore.BeginTransactionRequest.IsolationLevel:\x08SNAPSHOT\"0\n\x0eIsolationLevel\x12\x0c\n\x08SNAPSHOT\x10\x00\x12\x10\n\x0cSERIALIZABLE\x10\x01\"/\n\x18\x42\x65ginTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"&\n\x0fRollbackRequest\x12\x13\n\x0btransaction\x18\x01 \x02(\x0c\"\x12\n\x10RollbackResponse\"\xf4\x01\n\rCommitRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x32\n\x08mutation\x18\x02 \x01(\x0b\x32 .api.services.datastore.Mutation\x12G\n\x04mode\x18\x05 \x01(\x0e\x32*.api.services.datastore.CommitRequest.Mode:\rTRANSACTIONAL\x12\x1f\n\x10ignore_read_only\x18\x07 \x01(\x08:\x05\x66\x61lse\"0\n\x04Mode\x12\x11\n\rTRANSACTIONAL\x10\x01\x12\x15\n\x11NON_TRANSACTIONAL\x10\x02\"Q\n\x0e\x43ommitResponse\x12?\n\x0fmutation_result\x18\x01 \x01(\x0b\x32&.api.services.datastore.MutationResult\">\n\x12\x41llocateIdsRequest\x12(\n\x03key\x18\x01 \x03(\x0b\x32\x1b.api.services.datastore.Key\"?\n\x13\x41llocateIdsResponse\x12(\n\x03key\x18\x01 \x03(\x0b\x32\x1b.api.services.datastore.Key2\xed\x04\n\x10\x44\x61tastoreService\x12Y\n\x06Lookup\x12%.api.services.datastore.LookupRequest\x1a&.api.services.datastore.LookupResponse\"\x00\x12_\n\x08RunQuery\x12\'.api.services.datastore.RunQueryRequest\x1a(.api.services.datastore.RunQueryResponse\"\x00\x12w\n\x10\x42\x65ginTransaction\x12/.api.services.datastore.BeginTransactionRequest\x1a\x30.api.services.datastore.BeginTransactionResponse\"\x00\x12Y\n\x06\x43ommit\x12%.api.services.datastore.CommitRequest\x1a&.api.services.datastore.CommitResponse\"\x00\x12_\n\x08Rollback\x12\'.api.services.datastore.RollbackRequest\x1a(.api.services.datastore.RollbackResponse\"\x00\x12h\n\x0b\x41llocateIds\x12*.api.services.datastore.AllocateIdsRequest\x1a+.api.services.datastore.AllocateIdsResponse\"\x00\x42#\n!com.google.api.services.datastore')
 
 
 
@@ -38,8 +38,8 @@ _ENTITYRESULT_RESULTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=900,
-  serialized_end=952,
+  serialized_start=1042,
+  serialized_end=1094,
 )
 
 _PROPERTYEXPRESSION_AGGREGATIONFUNCTION = _descriptor.EnumDescriptor(
@@ -55,8 +55,8 @@ _PROPERTYEXPRESSION_AGGREGATIONFUNCTION = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1566,
-  serialized_end=1598,
+  serialized_start=1708,
+  serialized_end=1740,
 )
 
 _PROPERTYORDER_DIRECTION = _descriptor.EnumDescriptor(
@@ -76,8 +76,8 @@ _PROPERTYORDER_DIRECTION = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1758,
-  serialized_end=1800,
+  serialized_start=1900,
+  serialized_end=1942,
 )
 
 _COMPOSITEFILTER_OPERATOR = _descriptor.EnumDescriptor(
@@ -93,8 +93,8 @@ _COMPOSITEFILTER_OPERATOR = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2081,
-  serialized_end=2100,
+  serialized_start=2223,
+  serialized_end=2242,
 )
 
 _PROPERTYFILTER_OPERATOR = _descriptor.EnumDescriptor(
@@ -130,8 +130,8 @@ _PROPERTYFILTER_OPERATOR = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2295,
-  serialized_end=2418,
+  serialized_start=2437,
+  serialized_end=2560,
 )
 
 _QUERYRESULTBATCH_MORERESULTSTYPE = _descriptor.EnumDescriptor(
@@ -155,8 +155,8 @@ _QUERYRESULTBATCH_MORERESULTSTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2972,
-  serialized_end=3058,
+  serialized_start=3164,
+  serialized_end=3250,
 )
 
 _READOPTIONS_READCONSISTENCY = _descriptor.EnumDescriptor(
@@ -180,8 +180,8 @@ _READOPTIONS_READCONSISTENCY = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=3556,
-  serialized_end=3612,
+  serialized_start=3748,
+  serialized_end=3804,
 )
 
 _BEGINTRANSACTIONREQUEST_ISOLATIONLEVEL = _descriptor.EnumDescriptor(
@@ -201,8 +201,8 @@ _BEGINTRANSACTIONREQUEST_ISOLATIONLEVEL = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=4347,
-  serialized_end=4395,
+  serialized_start=4539,
+  serialized_end=4587,
 )
 
 _COMMITREQUEST_MODE = _descriptor.EnumDescriptor(
@@ -222,8 +222,8 @@ _COMMITREQUEST_MODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=4670,
-  serialized_end=4718,
+  serialized_start=4895,
+  serialized_end=4943,
 )
 
 
@@ -338,6 +338,41 @@ _KEY = _descriptor.Descriptor(
 )
 
 
+_GEOPOINT = _descriptor.Descriptor(
+  name='GeoPoint',
+  full_name='api.services.datastore.GeoPoint',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='latitude', full_name='api.services.datastore.GeoPoint.latitude', index=0,
+      number=1, type=1, cpp_type=5, label=2,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='longitude', full_name='api.services.datastore.GeoPoint.longitude', index=1,
+      number=2, type=1, cpp_type=5, label=2,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=285,
+  serialized_end=332,
+)
+
+
 _VALUE = _descriptor.Descriptor(
   name='Value',
   full_name='api.services.datastore.Value',
@@ -402,28 +437,35 @@ _VALUE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='entity_value', full_name='api.services.datastore.Value.entity_value', index=8,
+      name='geo_point_value', full_name='api.services.datastore.Value.geo_point_value', index=8,
+      number=8, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='entity_value', full_name='api.services.datastore.Value.entity_value', index=9,
       number=6, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='list_value', full_name='api.services.datastore.Value.list_value', index=9,
+      name='list_value', full_name='api.services.datastore.Value.list_value', index=10,
       number=7, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='meaning', full_name='api.services.datastore.Value.meaning', index=10,
+      name='meaning', full_name='api.services.datastore.Value.meaning', index=11,
       number=14, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='indexed', full_name='api.services.datastore.Value.indexed', index=11,
+      name='indexed', full_name='api.services.datastore.Value.indexed', index=12,
       number=15, type=8, cpp_type=7, label=1,
       has_default_value=True, default_value=True,
       message_type=None, enum_type=None, containing_type=None,
@@ -438,8 +480,8 @@ _VALUE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=286,
-  serialized_end=658,
+  serialized_start=335,
+  serialized_end=766,
 )
 
 
@@ -473,8 +515,8 @@ _PROPERTY = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=660,
-  serialized_end=730,
+  serialized_start=768,
+  serialized_end=838,
 )
 
 
@@ -508,8 +550,8 @@ _ENTITY = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=732,
-  serialized_end=834,
+  serialized_start=840,
+  serialized_end=942,
 )
 
 
@@ -527,6 +569,20 @@ _ENTITYRESULT = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='version', full_name='api.services.datastore.EntityResult.version', index=1,
+      number=2, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='cursor', full_name='api.services.datastore.EntityResult.cursor', index=2,
+      number=3, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value="",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -537,8 +593,8 @@ _ENTITYRESULT = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=836,
-  serialized_end=952,
+  serialized_start=945,
+  serialized_end=1094,
 )
 
 
@@ -621,8 +677,8 @@ _QUERY = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=955,
-  serialized_end=1319,
+  serialized_start=1097,
+  serialized_end=1461,
 )
 
 
@@ -649,8 +705,8 @@ _KINDEXPRESSION = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=1321,
-  serialized_end=1351,
+  serialized_start=1463,
+  serialized_end=1493,
 )
 
 
@@ -677,8 +733,8 @@ _PROPERTYREFERENCE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=1353,
-  serialized_end=1386,
+  serialized_start=1495,
+  serialized_end=1528,
 )
 
 
@@ -713,8 +769,8 @@ _PROPERTYEXPRESSION = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=1389,
-  serialized_end=1598,
+  serialized_start=1531,
+  serialized_end=1740,
 )
 
 
@@ -749,8 +805,8 @@ _PROPERTYORDER = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=1601,
-  serialized_end=1800,
+  serialized_start=1743,
+  serialized_end=1942,
 )
 
 
@@ -784,8 +840,8 @@ _FILTER = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=1803,
-  serialized_end=1943,
+  serialized_start=1945,
+  serialized_end=2085,
 )
 
 
@@ -820,8 +876,8 @@ _COMPOSITEFILTER = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=1946,
-  serialized_end=2100,
+  serialized_start=2088,
+  serialized_end=2242,
 )
 
 
@@ -863,8 +919,8 @@ _PROPERTYFILTER = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2103,
-  serialized_end=2418,
+  serialized_start=2245,
+  serialized_end=2560,
 )
 
 
@@ -912,8 +968,8 @@ _GQLQUERY = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2421,
-  serialized_end=2595,
+  serialized_start=2563,
+  serialized_end=2737,
 )
 
 
@@ -954,8 +1010,8 @@ _GQLQUERYARG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2597,
-  serialized_end=2686,
+  serialized_start=2739,
+  serialized_end=2828,
 )
 
 
@@ -981,22 +1037,36 @@ _QUERYRESULTBATCH = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='end_cursor', full_name='api.services.datastore.QueryResultBatch.end_cursor', index=2,
+      name='skipped_cursor', full_name='api.services.datastore.QueryResultBatch.skipped_cursor', index=2,
+      number=3, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value="",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='end_cursor', full_name='api.services.datastore.QueryResultBatch.end_cursor', index=3,
       number=4, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value="",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='more_results', full_name='api.services.datastore.QueryResultBatch.more_results', index=3,
+      name='more_results', full_name='api.services.datastore.QueryResultBatch.more_results', index=4,
       number=5, type=14, cpp_type=8, label=2,
       has_default_value=False, default_value=1,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='skipped_results', full_name='api.services.datastore.QueryResultBatch.skipped_results', index=4,
+      name='skipped_results', full_name='api.services.datastore.QueryResultBatch.skipped_results', index=5,
       number=6, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='snapshot_version', full_name='api.services.datastore.QueryResultBatch.snapshot_version', index=6,
+      number=7, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -1011,8 +1081,8 @@ _QUERYRESULTBATCH = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2689,
-  serialized_end=3058,
+  serialized_start=2831,
+  serialized_end=3250,
 )
 
 
@@ -1074,8 +1144,8 @@ _MUTATION = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3061,
-  serialized_end=3331,
+  serialized_start=3253,
+  serialized_end=3523,
 )
 
 
@@ -1109,8 +1179,8 @@ _MUTATIONRESULT = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3333,
-  serialized_end=3429,
+  serialized_start=3525,
+  serialized_end=3621,
 )
 
 
@@ -1145,8 +1215,8 @@ _READOPTIONS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3432,
-  serialized_end=3612,
+  serialized_start=3624,
+  serialized_end=3804,
 )
 
 
@@ -1180,8 +1250,8 @@ _LOOKUPREQUEST = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3614,
-  serialized_end=3730,
+  serialized_start=3806,
+  serialized_end=3922,
 )
 
 
@@ -1222,8 +1292,8 @@ _LOOKUPRESPONSE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3733,
-  serialized_end=3904,
+  serialized_start=3925,
+  serialized_end=4096,
 )
 
 
@@ -1271,8 +1341,8 @@ _RUNQUERYREQUEST = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3907,
-  serialized_end=4141,
+  serialized_start=4099,
+  serialized_end=4333,
 )
 
 
@@ -1299,8 +1369,8 @@ _RUNQUERYRESPONSE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4143,
-  serialized_end=4218,
+  serialized_start=4335,
+  serialized_end=4410,
 )
 
 
@@ -1328,8 +1398,8 @@ _BEGINTRANSACTIONREQUEST = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4221,
-  serialized_end=4395,
+  serialized_start=4413,
+  serialized_end=4587,
 )
 
 
@@ -1356,8 +1426,8 @@ _BEGINTRANSACTIONRESPONSE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4397,
-  serialized_end=4444,
+  serialized_start=4589,
+  serialized_end=4636,
 )
 
 
@@ -1384,8 +1454,8 @@ _ROLLBACKREQUEST = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4446,
-  serialized_end=4484,
+  serialized_start=4638,
+  serialized_end=4676,
 )
 
 
@@ -1405,8 +1475,8 @@ _ROLLBACKRESPONSE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4486,
-  serialized_end=4504,
+  serialized_start=4678,
+  serialized_end=4696,
 )
 
 
@@ -1438,6 +1508,13 @@ _COMMITREQUEST = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='ignore_read_only', full_name='api.services.datastore.CommitRequest.ignore_read_only', index=3,
+      number=7, type=8, cpp_type=7, label=1,
+      has_default_value=True, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -1448,8 +1525,8 @@ _COMMITREQUEST = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4507,
-  serialized_end=4718,
+  serialized_start=4699,
+  serialized_end=4943,
 )
 
 
@@ -1476,8 +1553,8 @@ _COMMITRESPONSE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4720,
-  serialized_end=4801,
+  serialized_start=4945,
+  serialized_end=5026,
 )
 
 
@@ -1504,8 +1581,8 @@ _ALLOCATEIDSREQUEST = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4803,
-  serialized_end=4865,
+  serialized_start=5028,
+  serialized_end=5090,
 )
 
 
@@ -1532,14 +1609,15 @@ _ALLOCATEIDSRESPONSE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4867,
-  serialized_end=4930,
+  serialized_start=5092,
+  serialized_end=5155,
 )
 
 _KEY_PATHELEMENT.containing_type = _KEY;
 _KEY.fields_by_name['partition_id'].message_type = _PARTITIONID
 _KEY.fields_by_name['path_element'].message_type = _KEY_PATHELEMENT
 _VALUE.fields_by_name['key_value'].message_type = _KEY
+_VALUE.fields_by_name['geo_point_value'].message_type = _GEOPOINT
 _VALUE.fields_by_name['entity_value'].message_type = _ENTITY
 _VALUE.fields_by_name['list_value'].message_type = _VALUE
 _PROPERTY.fields_by_name['value'].message_type = _VALUE
@@ -1602,6 +1680,7 @@ _ALLOCATEIDSREQUEST.fields_by_name['key'].message_type = _KEY
 _ALLOCATEIDSRESPONSE.fields_by_name['key'].message_type = _KEY
 DESCRIPTOR.message_types_by_name['PartitionId'] = _PARTITIONID
 DESCRIPTOR.message_types_by_name['Key'] = _KEY
+DESCRIPTOR.message_types_by_name['GeoPoint'] = _GEOPOINT
 DESCRIPTOR.message_types_by_name['Value'] = _VALUE
 DESCRIPTOR.message_types_by_name['Property'] = _PROPERTY
 DESCRIPTOR.message_types_by_name['Entity'] = _ENTITY
@@ -1650,6 +1729,12 @@ class Key(_message.Message):
   DESCRIPTOR = _KEY
 
   # @@protoc_insertion_point(class_scope:api.services.datastore.Key)
+
+class GeoPoint(_message.Message):
+  __metaclass__ = _reflection.GeneratedProtocolMessageType
+  DESCRIPTOR = _GEOPOINT
+
+  # @@protoc_insertion_point(class_scope:api.services.datastore.GeoPoint)
 
 class Value(_message.Message):
   __metaclass__ = _reflection.GeneratedProtocolMessageType

--- a/python/setup.py
+++ b/python/setup.py
@@ -15,7 +15,7 @@
 #
 from setuptools import setup
 
-__version__ = 'v1beta2-rev1-2.1.0'
+__version__ = 'v1beta2-rev1-3.0.0'
 
 setup(
     name='googledatastore',


### PR DESCRIPTION
Push a new version with 3.0.0, changing the QuerySplitter interface to support PartitionIds (for namespaces).