### PR TITLE
fixed transaction ID extraction from response

### DIFF
--- a/ruby/demos/trivial/adams.rb
+++ b/ruby/demos/trivial/adams.rb
@@ -56,7 +56,7 @@ resp = client.execute(
   :body_object => {})
 
 # Get the transaction handle
-tx = Base64.encode64(resp.data.transaction)
+tx = JSON.parse(resp.response.body)['transaction']
 
 # Get the entity by key.
 resp = client.execute(


### PR DESCRIPTION
transaction ID is not a Base64-encoded string, so encoding in Base64 does not work.
Simply extract the string directly from the JSON-encoded server response