### PR TITLE
Fix the "trivial" demo

### DIFF
--- a/java/demos/src/main/java/com/google/api/services/datastore/demos/trivial/Adams.java
+++ b/java/demos/src/main/java/com/google/api/services/datastore/demos/trivial/Adams.java
@@ -104,10 +104,16 @@ public class Adams {
       // the transaction.
       datastore.commit(creq.build());
       // Get `question` property value.
-      String question = entity.getProperty(0).getValue().getStringValue();
-      // Get `answer` property value.
-      Long answer = entity.getProperty(1).getValue().getIntegerValue();
+      // The "question" property can be in either index 0 or index 1, and the
+      // other property is the "answer".
+      int questionIndex = 0;
+      if (!"question".equals(entity.getProperty(questionIndex).getName())) {
+        questionIndex = 1;
+      }
+      String question = entity.getProperty(questionIndex).getValue().getStringValue();
       System.out.println(question);
+      // Get `answer` property value.
+      Long answer = entity.getProperty((questionIndex + 1) % 2).getValue().getIntegerValue();
       String result = System.console().readLine("> ");
       if (result.equals(answer.toString())) {
         System.out.println("fascinating, extraordinary and, " +

--- a/java/demos/src/main/java/com/google/api/services/datastore/demos/trivial/Adams.java
+++ b/java/demos/src/main/java/com/google/api/services/datastore/demos/trivial/Adams.java
@@ -24,6 +24,7 @@ import com.google.protobuf.ByteString;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Map;
 
 /**
  * A trivial command-line application using the Datastore API.
@@ -104,16 +105,10 @@ public class Adams {
       // the transaction.
       datastore.commit(creq.build());
       // Get `question` property value.
-      // The "question" property can be in either index 0 or index 1, and the
-      // other property is the "answer".
-      int questionIndex = 0;
-      if (!"question".equals(entity.getProperty(questionIndex).getName())) {
-        questionIndex = 1;
-      }
-      String question = entity.getProperty(questionIndex).getValue().getStringValue();
-      System.out.println(question);
+      Map<String, Value> properties = DatastoreHelper.getPropertyMap(entity);
+      System.out.println(properties.get("question").getStringValue());      
       // Get `answer` property value.
-      Long answer = entity.getProperty((questionIndex + 1) % 2).getValue().getIntegerValue();
+      Long answer = properties.get("answer").getIntegerValue();
       String result = System.console().readLine("> ");
       if (result.equals(answer.toString())) {
         System.out.println("fascinating, extraordinary and, " +


### PR DESCRIPTION
The demo doesn't work if you run it for the second time or afterwards.

The reason is: the demo code hard-coded the getProperty(index) call to look for the "question" property at index 0 and answer property at index 1, but that's not always true (especially after you run this demo for the second time or afterwards where the Entity is read from the Datastore rather than a local copy)

Here is an output of the Entity read from Datastore, as you can see, the "answer" property is actually at index 0 when the entity is read from datastore, but let's not hard-code the index but use some logic to detect the property.  

found entity: key {
  partition_id {
    dataset_id: "s~bionic-baton-343"
  }
  path_element {
    kind: "Trivia"
    name: "hgtg"
  }
}
property {
  name: "answer"
  value {
    integer_value: 42
  }
}
property {
  name: "question"
  value {
    string_value: "Meaning of Life?"
  }
}