### PR TITLE
Remove log that credentials aren't provided.

### DIFF
--- a/java/datastore/src/main/java/com/google/datastore/v1beta3/client/DatastoreFactory.java
+++ b/java/datastore/src/main/java/com/google/datastore/v1beta3/client/DatastoreFactory.java
@@ -70,9 +70,6 @@ public class DatastoreFactory {
    */
   public HttpRequestFactory makeClient(DatastoreOptions options) {
     Credential credential = options.getCredential();
-    if (credential == null) {
-      logger.info("Not using any credentials");
-    }
     HttpTransport transport = options.getTransport();
     if (transport == null) {
       transport = credential == null ? new NetHttpTransport() : credential.getTransport();


### PR DESCRIPTION
This log is correct only part of the time, since credentials can also be provided via HttpRequestInitializer.  /cc @pcostell @aozarov