### PR TITLE
Update httplib and oauth2client versions

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -28,8 +28,8 @@ setup(
     packages=['googledatastore'],
     package_dir={'googledatastore': 'googledatastore'},
     install_requires=[
-        'httplib2==0.8',
-        'oauth2client==2.0.1',
+        'httplib2>=0.9.1,<0.10',
+        'oauth2client>=2.0.1,<4.0.0',
         'proto-google-datastore-v1==1.2.0',
         'pycrypto==2.6',
         'pyOpenSSL',


### PR DESCRIPTION
Tying httplib2 and oauth2client to specific versions causes pip install problems when using googledatastore with other libraries. Hence making it support a range of versions. 