### PR TITLE
Remove dependencies that are not required

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -31,10 +31,6 @@ setup(
         'httplib2>=0.9.1,<0.10',
         'oauth2client>=2.0.1,<4.0.0',
         'proto-google-datastore-v1==1.2.0',
-        'pycrypto==2.6',
-        'pyOpenSSL',
-        'six',
-        'uritemplate==0.6',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
pyOpenSSL seems to require some libffi libraries to be installed, or else the pip install fails (http://stackoverflow.com/questions/31508612/pip-install-unable-to-find-ffi-h-even-though-it-recognizes-libffi)

It looks like datastore doesn't need this dependency. 