### PR TITLE
Release 1.5 with ID reservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ pip install googledatastore
 <dependency>
   <groupId>com.google.cloud.datastore</groupId>
   <artifactId>datastore-v1-protos</artifactId>
-  <version>1.3.0</version>
+  <version>1.5.0</version>
 </dependency>
 <dependency>
   <groupId>com.google.cloud.datastore</groupId>
   <artifactId>datastore-v1-proto-client</artifactId>
-  <version>1.4.1</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 

--- a/java/datastore/pom.xml
+++ b/java/datastore/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.google.cloud.datastore</groupId>
   <artifactId>datastore-v1-proto-client</artifactId>
-  <version>1.4.1</version>
+  <version>1.5.0</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
 
@@ -31,7 +31,7 @@
   <parent>
     <groupId>com.google.cloud.datastore</groupId>
     <artifactId>datastore-v1-proto-client-parent</artifactId>
-    <version>1.4.1</version>
+    <version>1.5.0</version>
   </parent>
 
   <dependencies>

--- a/java/datastore/src/main/java/com/google/datastore/v1/client/Datastore.java
+++ b/java/datastore/src/main/java/com/google/datastore/v1/client/Datastore.java
@@ -23,6 +23,8 @@ import com.google.datastore.v1.CommitRequest;
 import com.google.datastore.v1.CommitResponse;
 import com.google.datastore.v1.LookupRequest;
 import com.google.datastore.v1.LookupResponse;
+import com.google.datastore.v1.ReserveIdsRequest;
+import com.google.datastore.v1.ReserveIdsResponse;
 import com.google.datastore.v1.RollbackRequest;
 import com.google.datastore.v1.RollbackResponse;
 import com.google.datastore.v1.RunQueryRequest;
@@ -94,6 +96,14 @@ public class Datastore {
       return LookupResponse.parseFrom(is);
     } catch (IOException exception) {
       throw invalidResponseException("lookup", exception);
+    }
+  }
+
+  public ReserveIdsResponse reserveIds(ReserveIdsRequest request) throws DatastoreException {
+    try (InputStream is = remoteRpc.call("reserveIds", request)) {
+      return ReserveIdsResponse.parseFrom(is);
+    } catch (IOException exception) {
+      throw invalidResponseException("reserveIds", exception);
     }
   }
 

--- a/java/datastore/src/test/java/com/google/datastore/v1/client/DatastoreTest.java
+++ b/java/datastore/src/test/java/com/google/datastore/v1/client/DatastoreTest.java
@@ -46,6 +46,8 @@ import com.google.datastore.v1.EntityResult;
 import com.google.datastore.v1.LookupRequest;
 import com.google.datastore.v1.LookupResponse;
 import com.google.datastore.v1.QueryResultBatch;
+import com.google.datastore.v1.ReserveIdsRequest;
+import com.google.datastore.v1.ReserveIdsResponse;
 import com.google.datastore.v1.RollbackRequest;
 import com.google.datastore.v1.RollbackResponse;
 import com.google.datastore.v1.RunQueryRequest;
@@ -272,6 +274,13 @@ public class DatastoreTest {
     request.setTransaction(ByteString.copyFromUtf8("project-id"));
     CommitResponse.Builder response = CommitResponse.newBuilder();
     expectRpc("commit", request.build(), response.build());
+  }
+
+  @Test
+  public void reserveIds() throws Exception {
+    ReserveIdsRequest.Builder request = ReserveIdsRequest.newBuilder();
+    ReserveIdsResponse.Builder response = ReserveIdsResponse.newBuilder();
+    expectRpc("reserveIds", request.build(), response.build());
   }
 
   @Test

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.google.cloud.datastore</groupId>
   <artifactId>datastore-v1-proto-client-parent</artifactId>
-  <version>1.4.1</version>
+  <version>1.5.0</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <url>https://cloud.google.com/datastore/</url>
@@ -63,13 +63,13 @@
       <dependency>
         <groupId>com.google.cloud.datastore</groupId>
         <artifactId>datastore-v1-protos</artifactId>
-        <version>1.3.0</version>
+        <version>1.5.0</version>
       </dependency>
 
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client</artifactId>
-        <version>1.20.0</version>
+        <version>1.23.0</version>
         <exclusions>
           <exclusion>
             <artifactId>guava-jdk5</artifactId>


### PR DESCRIPTION
Remove V1 ID reservation flag guarding in low-level Java proto client now that the feature has been released.

Bump proto library version to 1.5. Bump proto client version to 1.5. Bump google-http-client version to 1.23.