### PR TITLE
1.6.0: Switch to proto-google-cloud-datastore-v1.

### DIFF
--- a/java/datastore/pom.xml
+++ b/java/datastore/pom.xml
@@ -17,10 +17,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
-  <groupId>com.google.cloud.datastore</groupId>
   <artifactId>datastore-v1-proto-client</artifactId>
-  <version>1.5.1</version>
+  <version>1.6.0</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
 
@@ -31,13 +29,13 @@
   <parent>
     <groupId>com.google.cloud.datastore</groupId>
     <artifactId>datastore-v1-proto-client-parent</artifactId>
-    <version>1.5.1</version>
+    <version>1.6.0</version>
   </parent>
 
   <dependencies>
     <dependency>
-      <groupId>com.google.cloud.datastore</groupId>
-      <artifactId>datastore-v1-protos</artifactId>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-datastore-v1</artifactId>
     </dependency>
 
     <dependency>

--- a/java/demos/pom.xml
+++ b/java/demos/pom.xml
@@ -29,14 +29,14 @@
   <parent>
     <groupId>com.google.cloud.datastore</groupId>
     <artifactId>datastore-v1-proto-client-parent</artifactId>
-    <version>1.4.1</version>
+    <version>1.6.0</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>com.google.cloud.datastore</groupId>
       <artifactId>datastore-v1-proto-client</artifactId>
-      <version>1.4.1</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.google.cloud.datastore</groupId>
   <artifactId>datastore-v1-proto-client-parent</artifactId>
-  <version>1.5.1</version>
+  <version>1.6.0</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <url>https://cloud.google.com/datastore/</url>
@@ -61,9 +61,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.cloud.datastore</groupId>
-        <artifactId>datastore-v1-protos</artifactId>
-        <version>1.5.0</version>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-datastore-v1</artifactId>
+        <version>0.1.27</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
cc @garrettjonesgoogle

This addresses #170.