### PR TITLE
Update version for httplib2

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=['googledatastore'],
     package_dir={'googledatastore': 'googledatastore'},
     install_requires=[
-        'httplib2>=0.9.1,<0.10',
+        'httplib2>=0.9.1,<=0.12.0',
         'oauth2client>=2.0.1,<4.0.0',
         'proto-google-cloud-datastore-v1>=0.90.0',
     ],


### PR DESCRIPTION
For #208 
Update the version upper bound for httplib2 to support latest version. Depending on an outdated version is causing version conflicts with other Google libraries like apache-beam.