### PR TITLE
Update Guava

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,7 +99,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>26.0-android</version>
+        <version>27.1-android</version>
       </dependency>
 
       <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,12 +70,6 @@
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client</artifactId>
         <version>1.28.0</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>guava-jdk5</artifactId>
-            <groupId>com.google.guava</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
@@ -105,7 +99,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>20.0</version>
+        <version>26.0-android</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
@wsh for consistency with rest of GCP orbit projects

Also, the JDK5 exclusion should no longer be necessary. 